### PR TITLE
Add support for UTF-8 in file context labels

### DIFF
--- a/libselinux/src/label_support.c
+++ b/libselinux/src/label_support.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <wchar.h>
 #include "label_internal.h"
 
 /*
@@ -35,13 +36,19 @@ static inline int read_spec_entry(char **entry, const char **ptr, size_t *len, c
 	*len = 0;
 
 	while (!isspace((unsigned char)**ptr) && **ptr != '\0') {
-		if (!isascii((unsigned char)**ptr)) {
+		size_t char_len;
+
+		char_len = mbrtowc(NULL, *ptr, MB_CUR_MAX, NULL);
+
+		if ((char_len == (size_t) -1) || (char_len == (size_t) -2)) {
 			errno = EINVAL;
-			*errbuf = "Non-ASCII characters found";
+			*errbuf = "Invalid UTF-8 encoding";
 			return -1;
 		}
-		(*ptr)++;
-		(*len)++;
+
+		*ptr += char_len;
+		*len += char_len;
+
 	}
 
 	if (*len) {

--- a/libselinux/src/regex.c
+++ b/libselinux/src/regex.c
@@ -85,9 +85,11 @@ int regex_prepare_data(struct regex_data **regex, char const *pattern_string,
 	if (!(*regex))
 		return -1;
 
-	(*regex)->regex = pcre2_compile(
-	    (PCRE2_SPTR)pattern_string, PCRE2_ZERO_TERMINATED, PCRE2_DOTALL,
-	    &errordata->error_code, &errordata->error_offset, NULL);
+	(*regex)->regex = pcre2_compile((PCRE2_SPTR)pattern_string,
+					PCRE2_ZERO_TERMINATED,
+					PCRE2_DOTALL | PCRE2_UTF | PCRE2_UCP,
+					&errordata->error_code,
+					&errordata->error_offset, NULL);
 	if (!(*regex)->regex) {
 		goto err;
 	}

--- a/libselinux/utils/sefcontext_compile.c
+++ b/libselinux/utils/sefcontext_compile.c
@@ -1,6 +1,7 @@
 #include <endian.h>
 #include <errno.h>
 #include <getopt.h>
+#include <locale.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -550,6 +551,10 @@ int main(int argc, char *argv[])
 	struct saved_data *data = NULL;
 	struct spec_node *root = NULL;
 	struct sidtab stab = {};
+
+	/* Initialize locale for UTF-8 support */
+	setlocale(LC_ALL, "");
+
 
 	if (argc < 2)
 		usage(argv[0]);

--- a/libsemanage/src/semanage_store.c
+++ b/libsemanage/src/semanage_store.c
@@ -57,6 +57,7 @@ typedef struct dbase_policydb dbase_t;
 #include <sys/wait.h>
 #include <limits.h>
 #include <libgen.h>
+#include <locale.h>
 
 #include "debug.h"
 #include "utilities.h"
@@ -1479,6 +1480,11 @@ static int semanage_exec_prog(semanage_handle_t * sh,
 	char **argv;
 	pid_t forkval;
 	int status = 0;
+	char *envp[] = { NULL, NULL};
+
+	/* we expect that locales are already initialized */
+	if (asprintf(&envp[0], "LC_CTYPE=%s", setlocale(LC_CTYPE, NULL)) == -1)
+		envp[0] = NULL;
 
 	argv = split_args(e->path, e->args, new_name, old_name);
 	if (argv == NULL) {
@@ -1492,11 +1498,13 @@ static int semanage_exec_prog(semanage_handle_t * sh,
 	if (forkval == 0) {
 		/* child process.  file descriptors will be closed
 		 * because they were set as close-on-exec. */
-		execve(e->path, argv, NULL);
+		execve(e->path, argv, envp);
 		_exit(EXIT_FAILURE);	/* if execve() failed */
 	}
 
 	free_argv(argv);
+	if (envp[0])
+		free(envp[0]);
 
 	if (forkval == -1) {
 		ERR(sh, "Error while forking process.");

--- a/policycoreutils/semodule/semodule.c
+++ b/policycoreutils/semodule/semodule.c
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <libgen.h>
 #include <limits.h>
+#include <locale.h>
 
 #include <sepol/cil/cil.h>
 #include <semanage/modules.h>
@@ -418,6 +419,10 @@ int main(int argc, char *argv[])
 	int i, commit = 0;
 	int result;
 	int status = EXIT_FAILURE;
+
+	/* Initialize locale for UTF-8 support */
+	setlocale(LC_ALL, "");
+
 	const char *genhomedirconargv[] = { "genhomedircon", "-B", "-n" };
 	create_signal_handlers();
 	if (strcmp(basename(argv[0]), "genhomedircon") == 0) {

--- a/policycoreutils/setfiles/setfiles.c
+++ b/policycoreutils/setfiles/setfiles.c
@@ -7,6 +7,7 @@
 #include <regex.h>
 #include <sys/vfs.h>
 #include <libgen.h>
+#include <locale.h>
 #ifdef USE_AUDIT
 #include <libaudit.h>
 
@@ -152,6 +153,9 @@ int main(int argc, char **argv)
 	union selinux_callback cb;
 	long unsigned skipped_errors;
 	long unsigned relabeled_files;
+
+	/* Initialize locale for UTF-8 support */
+	setlocale(LC_ALL, "");
 
 	/* Initialize variables */
 	memset(&r_opts, 0, sizeof(r_opts));


### PR DESCRIPTION
- libselinux to be able to read UTF-8 spec entries
- libselinux to compile regexes with UTF strings and unicode properties
- initialize locales in setfiles, sefcontext_compile
- semanage_exec_prog to execute external programs with LC_CTYPE set to the current environment

Please read [CONTRIBUTING.md](https://github.com/SELinuxProject/selinux/blob/main/CONTRIBUTING.md)

## Contributing Code

Post the patch for the review to the
[SELinux mailing list](https://lore.kernel.org/selinux) at
[selinux@vger.kernel.org](mailto:selinux@vger.kernel.org).

When preparing patches, please follow these guidelines:

-   Patches should apply with git am
-   Must apply against HEAD of the main branch
-   Separate large patches into logical patches
-   Patch descriptions must end with your "Signed-off-by" line. This means your
    code meets the Developer's certificate of origin, see below.
